### PR TITLE
Fix object passed to modify,erase is not in multi_index error

### DIFF
--- a/src/eoshtlc.cpp
+++ b/src/eoshtlc.cpp
@@ -7,7 +7,7 @@ void eoshtlc::on_transfer(name from, name to, asset quantity, string memo) {
    if (from == _self) return;
 
    htlcs idx(_self, from.value);
-   auto it = idx.get(htlc::hash(memo));
+   const auto& it = idx.get(htlc::hash(memo));
 
    check(!it.activated, "contract is already activated");
    check(it.value == extended_asset{quantity, get_first_receiver()}, "token amount not match: " + it.value.quantity.to_string() + "@" + it.value.contract.to_string());
@@ -35,7 +35,7 @@ void eoshtlc::newcontract(name owner, string contract_name, name recipient, exte
 
 void eoshtlc::withdraw(name owner, string contract_name, checksum256 preimage) {
    htlcs idx(_self, owner.value);
-   auto it = idx.get(htlc::hash(contract_name));
+   const auto& it = idx.get(htlc::hash(contract_name));
    check(it.activated, "contract not activated");
 
    // `preimage` works as a key here.
@@ -54,7 +54,7 @@ void eoshtlc::cancel(name owner, string contract_name) {
    require_auth(owner);
 
    htlcs idx(_self, owner.value);
-   auto it = idx.get(htlc::hash(contract_name));
+   const auto& it = idx.get(htlc::hash(contract_name));
 
    check(it.timelock < current_time_point(), "contract not expired");
 


### PR DESCRIPTION
```
Error 3050003: eosio_assert_message assertion failure
Error Details:
assertion failure with message: object passed to modify is not in multi_index
```
Lost reference to entry within multi-index through `get` and `modify`, `erase`.

## changes
- auto type iterator to const auto& type

ref. https://github.com/EOSIO/eos/issues/5317 