### PR TITLE
 Use xxh64 when creating a primary key of contract 

### DIFF
--- a/include/eoshtlc/eoshtlc.hpp
+++ b/include/eoshtlc/eoshtlc.hpp
@@ -17,7 +17,7 @@ public:
       time_point_sec timelock;
       bool activated = false;
 
-      static uint64_t hash(string s) { return fasthash64(s.data(), s.size()); }
+      static uint64_t hash(string s) { return xxh64(s.data(), s.size()); }
       uint64_t primary_key()const { return hash(contract_name); }
 
       EOSLIB_SERIALIZE(htlc, (contract_name)(recipient)(value)(hashlock)(timelock)(activated))


### PR DESCRIPTION
`fasthash64` is not provided in node package, so it's inconvenient to look up HTLC with precalculated primary key. Use `xxh64` instead of `fasthash64` in primary key calculation.